### PR TITLE
Remove outdated travis instructions; not needed with Project.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ matrix:
 notifications:
   email: false
 
-# uncomment the following lines to override the default test script
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg, InteractiveUtils; versioninfo(); Pkg.clone(pwd()); Pkg.build("GraphIO"); Pkg.test("GraphIO"; coverage=true)'
-
 after_success:
     - julia -e 'using Pkg; cd(Pkg.dir("GraphIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
     - julia -e 'using Pkg; Pkg.add("Documenter")'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "GraphIO"
+uuid = "aa1b3936-2fda-51b9-ab35-c553d3a640a2"
+version = "0.5.0"
+
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+
+[compat]
+EzXML = "≥ 0.9.0"
+LightGraphs = "≥ 1.3.0"
+ParserCombinator = "≥ 2.0.0"
+julia = "≥ 0.7.0"
+
+[extras]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["CodecZlib", "LightGraphs", "EzXML", "ParserCombinator", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-LightGraphs 1.1.0
-SimpleTraits
-Requires

--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -28,27 +28,23 @@ function _dot_read_one_graph(pg::Parsers.DOT.Graph)
     return g
 end
 
+_name(pg::Parsers.DOT.Graph) =
+    pg.id !== nothing ? pg.id.id :
+    Parsers.DOT.StringID(pg.directed ? "digraph" : "graph")
+
 function loaddot(io::IO, gname::String)
     p = Parsers.DOT.parse_dot(read(io, String))
     for pg in p
-        isdir = pg.directed
-        possname = isdir ? Parsers.DOT.StringID("digraph") : Parsers.DOT.StringID("graph")
-        name = get(pg.id, possname).id
-        name == gname && return _dot_read_one_graph(pg)
+        _name(pg) == gname && return _dot_read_one_graph(pg)
     end
     error("Graph $gname not found")
 end
 
 function loaddot_mult(io::IO)
     p = Parsers.DOT.parse_dot(read(io, String))
-
     graphs = Dict{String,AbstractGraph}()
-
     for pg in p
-        isdir = pg.directed
-        possname = isdir ? Parsers.DOT.StringID("digraph") : Parsers.DOT.StringID("graph")
-        name = get(pg.id, possname).id
-        graphs[name] = _dot_read_one_graph(pg)
+        graphs[_name(pg)] = _dot_read_one_graph(pg)
     end
     return graphs
 end

--- a/test/DOT/runtests.jl
+++ b/test/DOT/runtests.jl
@@ -3,7 +3,7 @@ using ParserCombinator
 using GraphIO.DOT
 
 @testset "DOT" begin
-    g = CompleteGraph(6)
+    g = complete_graph(6)
     dg = DiGraph(4)
     for e in [Edge(1,2), Edge(1,3), Edge(2,2), Edge(2,3), Edge(4,1), Edge(4,3)]
         add_edge!(dg, e)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,0 @@
-LightGraphs 1.1.0
-EzXML 0.9.0
-ParserCombinator 2.1.0
-CodecZlib

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,4 @@
 LightGraphs 1.1.0
 EzXML 0.9.0
-ParserCombinator 2.0.0
+ParserCombinator 2.1.0
 CodecZlib

--- a/test/graphio.jl
+++ b/test/graphio.jl
@@ -1,4 +1,4 @@
-# This file contains helper functions for testing the various 
+# This file contains helper functions for testing the various
 # GraphIO formats
 
 using LightGraphs
@@ -19,8 +19,8 @@ function gettempname()
     (f, fio) = mktemp()
     close(fio)
     return f
-end 
-        
+end
+
 function read_test(format::LightGraphs.AbstractGraphFormat, g::LightGraphs.AbstractGraph, gname::String="g",
     fname::AbstractString=""; testfail=false)
     @test loadgraph(fname, gname, format) == g
@@ -33,7 +33,6 @@ end
 function read_test_mult(format::LightGraphs.AbstractGraphFormat, d::Dict{String,G}, fname::AbstractString="") where G<: AbstractGraph
     rd = loadgraphs(fname, format)
     @test rd == d
-    
 end
 
 function write_test(format::LightGraphs.AbstractGraphFormat, g::LightGraphs.AbstractGraph, gname::String="g",

--- a/test/graphio.jl
+++ b/test/graphio.jl
@@ -4,14 +4,14 @@
 using LightGraphs
 
 graphs = Dict{String,Graph}(
-    "graph1"    => CompleteGraph(5), 
-    "graph2"    => PathGraph(6),
-    "graph3"    =>WheelGraph(4)
+    "graph1"    => complete_graph(5),
+    "graph2"    => path_graph(6),
+    "graph3"    => wheel_graph(4)
     )
 digraphs = Dict{String,DiGraph}(
-    "digraph1"   => CompleteDiGraph(5), 
-    "digraph2"   => PathDiGraph(6),
-    "digraph3"   => WheelDiGraph(4)
+    "digraph1"  => complete_digraph(5),
+    "digraph2"  => path_digraph(6),
+    "digraph3"  => wheel_digraph(4)
 )
 allgraphs = merge(graphs, digraphs)
 


### PR DESCRIPTION
I think this is why your PR (https://github.com/JuliaGraphs/GraphIO.jl/pull/24/) failed to build. With a project.toml, you don't need to set a custom `script` in travis anymore!

you can see what they do here for inspiration:
https://github.com/JuliaLang/Example.jl/blob/master/.travis.yml